### PR TITLE
Moved Nosto menu to Marketing » Nosto

### DIFF
--- a/etc/acl.xml
+++ b/etc/acl.xml
@@ -30,8 +30,10 @@
     <acl>
         <resources>
             <resource id="Magento_Backend::admin">
-                    <resource id="Nosto_Tagging::system_nosto" title="Nosto" sortOrder="500" >
+                <resource id="Magento_Backend::marketing">
+                    <resource id="Nosto_Tagging::nosto" title="Nosto" sortOrder="500" >
                         <resource id="Nosto_Tagging::system_nosto_account" title="Account Settings" sortOrder="10" />
+                    </resource>
                 </resource>
             </resource>
         </resources>

--- a/etc/adminhtml/menu.xml
+++ b/etc/adminhtml/menu.xml
@@ -27,7 +27,8 @@
 
 <!--suppress XmlUnboundNsPrefix -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Backend:etc/menu.xsd">
-<menu>
-    <add id="Nosto_Tagging::system_nosto" title="Nosto" module="Nosto_Tagging" sortOrder="500" resource="Nosto_Tagging::system_nosto_account" action="nosto/account" />
-</menu>
+    <menu>
+        <add id="Nosto_Tagging::nosto" title="Nosto" module="Nosto_Tagging" sortOrder="50" resource="Nosto_Tagging::nosto" parent="Magento_Backend::marketing"/>
+        <add id="Nosto_Tagging::system_nosto" title="Product Recommendations" module="Nosto_Tagging" sortOrder="10" resource="Nosto_Tagging::system_nosto_account" action="nosto/account" parent="Nosto_Tagging::nosto" />
+    </menu>
 </config>


### PR DESCRIPTION
## Problem
If every module has it's own admin menu section on the first level, the merchant's Magento Admin would soon become too long and messy.

## Expected Result
Nosto should be available from one of the existing sections, as suggested in this PR: Marketing » Nosto

![nosto-m2-menu-grouping](https://cloud.githubusercontent.com/assets/7068697/13956635/ceb8dc84-f049-11e5-8af3-b44d3be95efb.png)
